### PR TITLE
28 - Crear test para endpoint de creación de un BookSuggestion

### DIFF
--- a/app/controllers/api/v1/book_suggestions_controller.rb
+++ b/app/controllers/api/v1/book_suggestions_controller.rb
@@ -9,7 +9,8 @@ module Api
       private
 
       def book_suggestion_params
-        params.permit(:synopsis, :price, :author, :title, :link, :publisher, :year)
+        params.require(:book_suggestion)
+            .permit(:synopsis, :price, :author, :title, :link, :publisher, :year)
             .merge(user: current_user)
       end
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,10 +1,15 @@
 class ApiController < ApplicationController
   respond_to :json
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :invalid_record
 
   private
 
   def not_found
     render json: { error: "Record not found with id #{params[:id]}" }, status: :not_found
+  end
+
+  def invalid_record
+    render json: { error: "Record is invalid" }, status: :unprocessable_entity
   end
 end

--- a/spec/controllers/api/v1/book_suggestions_spec.rb
+++ b/spec/controllers/api/v1/book_suggestions_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Api::V1::BookSuggestionsController, type: :controller do
+  describe 'POST #create' do
+    context 'When creating a valid book suggestion' do
+      let!(:new_book_suggestion_attributes) { attributes_for(:book_suggestion) }
+
+      it 'creates a new book suggestion' do
+        expect do
+          post :create, params: { book_suggestion: new_book_suggestion_attributes }
+        end.to change { BookSuggestion.count }.by(1)
+      end
+
+      it 'responds with 201 status' do
+        post :create, params: { book_suggestion: new_book_suggestion_attributes }
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+
+  context 'When creating an invalid book suggestion' do
+    before do
+      post :create, params: { book_suggestion: {synopsis: 'test'} }
+    end
+
+    it 'doesn\'t create a new book suggestion' do
+      expect do
+        post :create, params: { book_suggestion: {synopsis: 'test'} }
+      end.to change { BookSuggestion.count }.by(0)
+    end
+
+    it 'returns error messages' do
+      expect(response.body['error']).to be_present
+    end
+
+    it 'responds with 422 status' do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/factories/book_suggestions.rb
+++ b/spec/factories/book_suggestions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :book_suggestion do
-    user { create(:user) }
+    user { build(:user) }
     synopsis { Faker::Book.title }
     price { Faker::Number.decimal(2, 3) }
     author { Faker::Book.author }


### PR DESCRIPTION
Trello Card: https://trello.com/c/6ULtLzvM/28-crear-test-para-endpoint-de-creaci%C3%B3n-de-un-booksuggestion

- Añadidos tests para endpoint de creación de nuevo book suggestion.
- Añadido rescue_from ActiveRecord::RecordInvalid in ApiController.
- Añadido require(:book_suggestion) a parámetros de BookSuggestionController.
- Cambiado 'create' por 'build' en book suggestion factory.